### PR TITLE
fixing TypeError: a bytes-like object is required, not str

### DIFF
--- a/recipe/src/spefile.py
+++ b/recipe/src/spefile.py
@@ -172,7 +172,7 @@ class PrincetonSPEFile():
     def _readAtString(self, pos, size):
         if pos is not None:
             self._fid.seek(pos)
-        return self._fid.read(size).rstrip(chr(0))
+        return self._fid.read(size).decode('ascii').rstrip(chr(0))
 
     def _readInt(self, pos):
         return self._readAtNumpy(pos, 1, numpy.int16)[0]


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
